### PR TITLE
Update pom.xml

### DIFF
--- a/sparkbench/ml/pom.xml
+++ b/sparkbench/ml/pom.xml
@@ -54,4 +54,37 @@
       <version>${mahout.version}</version>
     </dependency>
   </dependencies>
+         
+  <profiles>
+    <profile>
+      <id>spark2.0</id>
+      <activation>
+        <property>
+          <name>spark</name>
+          <value>2.0</value>
+        </property>
+      </activation>
+    </profile>         
+
+    <profile>
+      <id>spark2.1</id>
+      <activation>
+        <property>
+          <name>spark</name>
+          <value>2.1</value>
+        </property>
+      </activation>
+    </profile>  
+           
+    <profile>
+      <id>spark2.2</id>
+      <activation>
+        <property>
+          <name>spark</name>
+          <value>2.2</value>
+        </property>
+      </activation>
+    </profile>         
+        
+  </profiles>         
 </project>


### PR DESCRIPTION
Update pom.xml to avoid spark 1.6 build for ml workloads that using spark.ml package.
@VinceShieh Please help to check and merge this pom.